### PR TITLE
Landing Page - Basketball integration and stats incorporated

### DIFF
--- a/src/_services/bootstrapService.tsx
+++ b/src/_services/bootstrapService.tsx
@@ -51,7 +51,27 @@ export const BootstrapService = {
     proID: number
   ): Promise<BBBootstrap> => {
     return await GetCall<BBBootstrap>(
-      `${bbaUrl}bootstrap/${collegeID}/${proID}`
+      `${bbaUrl}bootstrap/one/${collegeID}/${proID}`
+    );
+  },
+
+  // ✅ Get Basketball Bootstrap Data
+  GetSecondBBABootstrapData: async (
+    collegeID: number,
+    proID: number
+  ): Promise<BBBootstrap> => {
+    return await GetCall<BBBootstrap>(
+      `${bbaUrl}bootstrap/two/${collegeID}/${proID}`
+    );
+  },
+
+  // ✅ Get Basketball Bootstrap Data
+  GetThirdBBABootstrapData: async (
+    collegeID: number,
+    proID: number
+  ): Promise<BBBootstrap> => {
+    return await GetCall<BBBootstrap>(
+      `${bbaUrl}bootstrap/three/${collegeID}/${proID}`
     );
   },
 };

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -106,6 +106,24 @@ export const Home = () => {
                 {nflTeam.Mascot}
               </PillButton>
             )}
+            {cbbTeam && (
+              <PillButton
+                variant="primaryOutline"
+                isSelected={selectedLeague === SimCBB}
+                onClick={() => SetTeam(SimCBB, cbbTeam)}
+              >
+                {cbbTeam.Team}
+              </PillButton>
+            )}
+            {nbaTeam && (
+              <PillButton
+                variant="primaryOutline"
+                isSelected={selectedLeague === SimNBA}
+                onClick={() => SetTeam(SimNBA, nbaTeam)}
+              >
+                {nbaTeam.Nickname}
+              </PillButton>
+            )}
             {chlTeam && (
               <PillButton
                 variant="primaryOutline"
@@ -124,24 +142,6 @@ export const Home = () => {
                 {phlTeam.Mascot}
               </PillButton>
             )}
-            {/* {cbbTeam && (
-              <PillButton
-                variant="primaryOutline"
-                isSelected={selectedLeague === SimCBB}
-                onClick={() => SetTeam(SimCBB, cbbTeam)}
-              >
-                {cbbTeam.Team}
-              </PillButton>
-            )} */}
-            {/* {nbaTeam && (
-              <PillButton
-                variant="primaryOutline"
-                isSelected={selectedLeague === SimNBA}
-                onClick={() => SetTeam(SimNBA, nbaTeam)}
-              >
-                {nbaTeam.Nickname}
-              </PillButton>
-            )} */}
           </ButtonGroup>
           {/* Refactor below code into component by league -- Football, Basketball, Baseball, Hockey */}
           {/* <div className="flex ml-4">

--- a/src/components/LandingPage/TeamLandingPage.tsx
+++ b/src/components/LandingPage/TeamLandingPage.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react";
 import { useAuthStore } from "../../context/AuthContext";
 import { useSimFBAStore } from "../../context/SimFBAContext";
+import { useSimBBAStore } from "../../context/SimBBAContext";
 import { useSimHCKStore } from "../../context/SimHockeyContext";
 import { Border } from "../../_design/Borders";
 import { 
   getLandingCFBData, 
-  getLandingNFLData, 
+  getLandingNFLData,
+  getLandingCBBData,
+  getLandingNBAData, 
   getLandingCHLData,
   getLandingPHLData 
 } from "./TeamLandingPageHelper";
@@ -53,6 +56,25 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
     isLoadingTwo 
   } = useSimFBAStore();
   const { 
+    collegeNotifications: cbbNotifications, 
+    proNotifications: nbaNotifications, 
+    allCBBStandings,
+    allProStandings: allNBAStandings, 
+    allCollegeGames: allCBBGames, 
+    allProGames: allNBAGames,
+    collegeNews: cbbNews, 
+    proNews: nbaNews,
+    cbbTeams, 
+    nbaTeams, 
+    topCBBPoints,
+    topCBBAssists,
+    topCBBRebounds,
+    topNBAPoints,
+    topNBAAssists,
+    topNBARebounds,
+    isLoadingTwo: isLoadingBB, 
+  } = useSimBBAStore();
+  const { 
     collegeNotifications: chlNotifications,
     proNotifications: phlNotifications,
     allCHLStandings,
@@ -65,7 +87,6 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
     phlTeams,
   } =
     useSimHCKStore();
-    console.log(phlTeams)
   const currentWeek = GetCurrentWeek(league, ts)
   const headers = Titles.headersMapping[league as LeagueType]
 
@@ -137,6 +158,64 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
         topNFLRushers, 
         topNFLReceivers, 
         proNews
+      ));
+        break;
+
+    case "SimCBB":
+      ({ 
+        teamStandings, 
+        teamNotifications,  
+        teamMatchUp, 
+        teamSchedule, 
+        homeLogo, 
+        awayLogo, 
+        homeLabel, 
+        awayLabel,
+        teamNews, 
+        teamStats, 
+        gameWeek 
+      } = getLandingCBBData(
+        team, 
+        currentWeek, 
+        league, 
+        currentUser, 
+        allCBBStandings, 
+        cbbNotifications, 
+        allCBBGames, 
+        cbbTeams, 
+        topCBBPoints,
+        topCBBAssists,
+        topCBBRebounds,
+        cbbNews
+        ));
+      break;
+
+    case "SimNBA":
+      ({ 
+        teamStandings, 
+        teamNotifications,  
+        teamMatchUp, 
+        teamSchedule, 
+        homeLogo, 
+        awayLogo, 
+        homeLabel, 
+        awayLabel, 
+        teamNews,
+        teamStats, 
+        gameWeek,
+      } = getLandingNBAData(
+        team, 
+        currentWeek, 
+        league, 
+        currentUser, 
+        allNBAStandings, 
+        nbaNotifications, 
+        allNBAGames, 
+        nbaTeams, 
+        topNBAPoints,
+        topNBAAssists,
+        topNBARebounds, 
+        nbaNews
       ));
         break;
 

--- a/src/components/LandingPage/TeamLandingPage.tsx
+++ b/src/components/LandingPage/TeamLandingPage.tsx
@@ -362,6 +362,7 @@ export const TeamLandingPage = ({ team, league, ts }: TeamLandingPageProps) => {
                 }}
               >
                 <TeamStats team={team}
+                          league={league}
                           header="Team Statistics"
                           teamStats={teamStats}
                           titles={headers}

--- a/src/components/LandingPage/TeamLandingPageComponents.tsx
+++ b/src/components/LandingPage/TeamLandingPageComponents.tsx
@@ -397,6 +397,7 @@ export const TeamMailbox = ({ team, notifications,
 
 interface TeamStatsProps {
   team: any;
+  league: League;
   header: string;
   teamStats: any;
   titles: any;
@@ -405,12 +406,76 @@ interface TeamStatsProps {
   isLoadingTwo: boolean;
 }
 
-export const TeamStats = ({ team, header, teamStats, titles,
+export const TeamStats = ({ team, league, header, teamStats, titles,
                             backgroundColor, borderColor, isLoadingTwo }:
                               TeamStatsProps) => {
 
   const textColorClass = getTextColorBasedOnBg(backgroundColor)                          
   const darkerBackgroundColor = darkenColor(backgroundColor, -5)
+  let boxOneFirstName, boxOneLastName, boxOnePosition, boxOneTopStat, boxOneBottomStat;
+  let boxTwoFirstName, boxTwoLastName, boxTwoPosition, boxTwoTopStat, boxTwoBottomStat;
+  let boxThreeFirstName, boxThreeLastName, boxThreePosition, boxThreeTopStat, boxThreeBottomStat;
+
+  switch (league) {
+    case "SimCFB":
+    case "SimNFL":
+      boxOneFirstName = teamStats.TopPasser?.FirstName;
+      boxOneLastName = teamStats.TopPasser?.LastName;
+      boxOnePosition = teamStats.TopPasser?.Position;
+      boxOneTopStat = teamStats.TopPasser?.SeasonStats?.PassingTDs;
+      boxOneBottomStat = teamStats.TopPasser?.SeasonStats?.PassingYards;
+      boxTwoFirstName = teamStats.TopRusher?.FirstName;
+      boxTwoLastName = teamStats.TopRusher?.LastName;
+      boxTwoPosition = teamStats.TopRusher?.Position;
+      boxTwoTopStat = teamStats.TopRusher?.SeasonStats?.RushingTDs;
+      boxTwoBottomStat = teamStats.TopRusher?.SeasonStats?.RushingYards;
+      boxThreeFirstName = teamStats.TopReceiver?.FirstName;
+      boxThreeLastName = teamStats.TopReceiver?.LastName;
+      boxThreePosition = teamStats.TopReceiver?.Position;
+      boxThreeTopStat = teamStats.TopReceiver?.SeasonStats?.ReceivingTDs;
+      boxThreeBottomStat = teamStats.TopReceiver?.SeasonStats?.ReceivingYards;
+      break;
+
+    case "SimCBB":
+    case "SimNBA":
+      boxOneFirstName = teamStats.TopPoints?.FirstName;
+      boxOneLastName = teamStats.TopPoints?.LastName;
+      boxOnePosition = teamStats.TopPoints?.Position;
+      boxOneTopStat = teamStats.TopPoints?.SeasonStats?.PPG.toFixed(1);
+      boxOneBottomStat = teamStats.TopPoints?.SeasonStats?.MinutesPerGame.toFixed(1);
+      boxTwoFirstName = teamStats.TopAssists?.FirstName;
+      boxTwoLastName = teamStats.TopAssists?.LastName;
+      boxTwoPosition = teamStats.TopAssists?.Position;
+      boxTwoTopStat = teamStats.TopAssists?.SeasonStats?.AssistsPerGame.toFixed(1);
+      boxTwoBottomStat = teamStats.TopAssists?.SeasonStats?.MinutesPerGame.toFixed(1);
+      boxThreeFirstName = teamStats.TopRebounds?.FirstName;
+      boxThreeLastName = teamStats.TopRebounds?.LastName;
+      boxThreePosition = teamStats.TopRebounds?.Position;
+      boxThreeTopStat = teamStats.TopRebounds?.SeasonStats?.ReboundsPerGame.toFixed(1);
+      boxThreeBottomStat = teamStats.TopRebounds?.SeasonStats?.MinutesPerGame.toFixed(1);
+      break;
+
+    case "SimCHL":
+    case "SimPHL":
+      boxOneFirstName = teamStats.TopPoints?.FirstName;
+      boxOneLastName = teamStats.TopPoints?.LastName;
+      boxOnePosition = teamStats.TopPoints?.Position;
+      boxOneTopStat = teamStats.TopPoints?.SeasonStats?.Points;
+      boxOneBottomStat = teamStats.TopPoints?.SeasonStats?.TimeOnIce.toFixed(1);
+      boxTwoFirstName = teamStats.TopGoals?.FirstName;
+      boxTwoLastName = teamStats.TopGoals?.LastName;
+      boxTwoPosition = teamStats.TopGoals?.Position;
+      boxTwoTopStat = teamStats.TopGoals?.SeasonStats?.Goals;
+      boxTwoBottomStat = teamStats.TopGoals?.SeasonStats?.TimeOnIce.toFixed(1);
+      boxThreeFirstName = teamStats.TopAssists?.FirstName;
+      boxThreeLastName = teamStats.TopAssists?.LastName;
+      boxThreePosition = teamStats.TopAssists?.Position;
+      boxThreeTopStat = teamStats.TopAssists?.SeasonStats?.Assists;
+      boxThreeBottomStat = teamStats.TopAssists?.SeasonStats?.TimeOnIce.toFixed(1);
+      break;
+    default:
+      break;  
+  }
   
   return (
     <SectionCards
@@ -439,20 +504,20 @@ export const TeamStats = ({ team, header, teamStats, titles,
               <div className="flex-col">
                 <div className="flex space-x-1">
                   <Text variant="small" classes={`${textColorClass} font-semibold text-right sm:text-center`}>
-                    {`${teamStats.TopPasser?.FirstName}`}
+                    {`${boxOneFirstName}`}
                   </Text>
                   <Text variant="small" classes={`${textColorClass} font-semibold text-right sm:text-center`}>
-                  {`${teamStats.TopPasser?.LastName}`}
+                  {`${boxOneLastName}`}
                   </Text>
                   <Text variant="small" classes={`${textColorClass} opacity-85`}>
-                    {`${teamStats.TopPasser?.Position}`}
+                    {`${boxOnePosition}`}
                   </Text>
                 </div>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopPasser?.SeasonStats?.PassingTDs} ${titles[3]}`}
+                    {`${boxOneTopStat} ${titles[3]}`}
                 </Text>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopPasser?.SeasonStats?.PassingYards} ${titles[4]}`}
+                    {`${boxOneBottomStat} ${titles[4]}`}
                 </Text>
               </div>
             </div>
@@ -469,20 +534,20 @@ export const TeamStats = ({ team, header, teamStats, titles,
               <div className="flex-col">
                 <div className="flex space-x-1">
                   <Text variant="small" classes={`${textColorClass} font-semibold text-right sm:text-center`}>
-                    {`${teamStats.TopRusher?.FirstName}`}
+                    {`${boxTwoFirstName}`}
                   </Text>
                   <Text variant="small" classes={`${textColorClass} font-semibold text-right sm:text-center`}>
-                    {`${teamStats.TopRusher?.LastName}`}
+                    {`${boxTwoLastName}`}
                   </Text>
                   <Text variant="small" classes={`${textColorClass} opacity-85`}>
-                    {`${teamStats.TopRusher?.Position}`}
+                    {`${boxTwoPosition}`}
                   </Text>
                 </div>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopRusher?.SeasonStats?.RushingTDs} ${titles[5]}`}
+                    {`${boxTwoTopStat} ${titles[5]}`}
                 </Text>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopRusher?.SeasonStats?.RushingYards} ${titles[6]}`}
+                    {`${boxTwoBottomStat} ${titles[6]}`}
                 </Text>
               </div>
             </div>
@@ -499,20 +564,20 @@ export const TeamStats = ({ team, header, teamStats, titles,
               <div className="flex-col">
                 <div className="flex space-x-1">
                   <Text variant="small" classes={`${textColorClass} font-semibold text-right sm:text-center`}>
-                    {`${teamStats.TopReceiver?.FirstName}`}
+                    {`${boxThreeFirstName}`}
                   </Text>
                   <Text variant="small" classes={`${textColorClass} font-semibold text-right sm:text-center`}>
-                    {`${teamStats.TopReceiver?.LastName}`}
+                    {`${boxThreeLastName}`}
                   </Text>
                   <Text variant="small" classes={`${textColorClass} opacity-85`}>
-                    {`${teamStats.TopReceiver?.Position}`}
+                    {`${boxThreePosition}`}
                   </Text>
                 </div>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopReceiver?.SeasonStats?.ReceivingTDs} ${titles[7]}`}
+                    {`${boxThreeTopStat} ${titles[7]}`}
                 </Text>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopReceiver?.SeasonStats?.ReceivingYards} ${titles[8]}`}
+                    {`${boxThreeBottomStat} ${titles[8]}`}
                 </Text>
               </div>
             </div>

--- a/src/components/LandingPage/TeamLandingPageComponents.tsx
+++ b/src/components/LandingPage/TeamLandingPageComponents.tsx
@@ -449,10 +449,10 @@ export const TeamStats = ({ team, header, teamStats, titles,
                   </Text>
                 </div>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopPasser?.SeasonStats?.PassingTDs} TDs`}
+                    {`${teamStats.TopPasser?.SeasonStats?.PassingTDs} ${titles[3]}`}
                 </Text>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopPasser?.SeasonStats?.PassingYards} Yards`}
+                    {`${teamStats.TopPasser?.SeasonStats?.PassingYards} ${titles[4]}`}
                 </Text>
               </div>
             </div>
@@ -479,10 +479,10 @@ export const TeamStats = ({ team, header, teamStats, titles,
                   </Text>
                 </div>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopRusher?.SeasonStats?.RushingTDs} TDs`}
+                    {`${teamStats.TopRusher?.SeasonStats?.RushingTDs} ${titles[5]}`}
                 </Text>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopRusher?.SeasonStats?.RushingYards} Yards`}
+                    {`${teamStats.TopRusher?.SeasonStats?.RushingYards} ${titles[6]}`}
                 </Text>
               </div>
             </div>
@@ -509,10 +509,10 @@ export const TeamStats = ({ team, header, teamStats, titles,
                   </Text>
                 </div>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopReceiver?.SeasonStats?.ReceivingTDs} TDs`}
+                    {`${teamStats.TopReceiver?.SeasonStats?.ReceivingTDs} ${titles[7]}`}
                 </Text>
                 <Text variant="alternate" classes={`${textColorClass} font-semibold`}>
-                    {`${teamStats.TopReceiver?.SeasonStats?.ReceivingYards} Yards`}
+                    {`${teamStats.TopReceiver?.SeasonStats?.ReceivingYards} ${titles[8]}`}
                 </Text>
               </div>
             </div>

--- a/src/components/LandingPage/TeamLandingPageHelper.tsx
+++ b/src/components/LandingPage/TeamLandingPageHelper.tsx
@@ -339,7 +339,6 @@ export const getLandingNFLData = (
         TopAssists: topAssists,
         TopRebounds: topRebounds
       };
-      console.log(teamStats)
   
       // Team News
       const teamNews = cbbNews
@@ -380,7 +379,6 @@ export const getLandingNFLData = (
         const teamStandings = allNBAStandings
           .filter((standings) => standings.ConferenceID === team.ConferenceID)
           .map((standings, index) => ({ ...standings, Rank: index + 1 }));
-          console.log(teamStandings)
         
         // Team Notifications
         const teamNotifications = nbaNotifications
@@ -446,7 +444,6 @@ export const getLandingNFLData = (
           TopAssists: topAssists,
           TopRebounds: topRebounds
         };
-        console.log(teamStats)
   
         // Team News
         const teamNews = nbaNews

--- a/src/components/LandingPage/TeamLandingPageHelper.tsx
+++ b/src/components/LandingPage/TeamLandingPageHelper.tsx
@@ -12,9 +12,20 @@ import {
   NewsLog 
 } from "../../models/footballModels";
 import { 
+  CollegeStandings as CBBStandings,
+  NBAStandings, 
+  Notification as BasketballNotification,
+  Match as CBBMatch,
+  NBAMatch as NBAMatch, 
+  Team as CBBTeam,
+  NBATeam,
+  CollegePlayer as CBBPlayer,
+  NBAPlayer,
+  NewsLog as BasketballNewsLog 
+} from "../../models/basketballModels";
+import { 
   CollegeStandings as CHLStandings,
   ProfessionalStandings as PHLStandings,
-  ProCapsheet as PHLCapsheet,
   Notification as HockeyNotification,
   CollegeGame as CHLGame,
   ProfessionalGame as PHLGame,
@@ -241,6 +252,220 @@ export const getLandingNFLData = (
       teamNews 
     };
   };
+
+  export const getLandingCBBData = (
+    team: any,
+    currentWeek: any,
+    league: League,
+    currentUser: any,
+    allCBBStandings: CBBStandings[],
+    cbbNotifications: BasketballNotification[],
+    allCBBGames: CBBMatch[],
+    allCBBTeams: CBBTeam[],
+    topCBBPoints: CBBPlayer[],
+    topCBBAssists: CBBPlayer[],
+    topCBBRebounds: CBBPlayer[],
+    cbbNews: BasketballNewsLog[],
+  ) => {
+      // Team Standings
+      const teamStandings = allCBBStandings
+        .filter((standings) => standings.ConferenceID === team.ConferenceID)
+        .map((standings, index) => ({ ...standings, Rank: index + 1 }));
+  
+      // Team Notifications
+      const teamNotifications = cbbNotifications
+        .filter((notification) => notification.TeamID === team.ID)
+        .reverse();
+  
+      // Team Match-Up
+      let foundMatch: CBBMatch[] | null = null;
+      let gameWeek = currentWeek;
+      for (let weekOffset = 0; weekOffset <= 10; weekOffset++) {
+        const testWeek = currentWeek + weekOffset;
+        const nextMatch = allCBBGames.filter(
+          (game) =>
+            (game.HomeTeamID === team.ID || game.AwayTeamID === team.ID) &&
+            game.Week === testWeek
+        );
+      
+        if (nextMatch.length > 0) {
+          foundMatch = nextMatch;
+          gameWeek = testWeek;
+          break;
+        }
+      }
+  
+      const teamMatchUp = foundMatch || [];
+      let homeLogo = "";
+      let awayLogo = "";
+      let homeLabel = "";
+      let awayLabel = "";
+      
+      if (teamMatchUp.length > 0) {
+        const homeRank = teamMatchUp[0].HomeTeamRank !== 0 
+          ? `#${teamMatchUp[0].HomeTeamRank} `
+          : "";
+        const awayRank = teamMatchUp[0].AwayTeamRank !== 0 
+          ? `#${teamMatchUp[0].AwayTeamRank} `
+          : "";
+      
+        homeLogo = getLogo(league, teamMatchUp[0].HomeTeamID, currentUser?.isRetro);
+        awayLogo = getLogo(league, teamMatchUp[0].AwayTeamID, currentUser?.isRetro);
+        homeLabel = `${homeRank}${teamMatchUp[0].HomeTeam}`;
+        awayLabel = `${awayRank}${teamMatchUp[0].AwayTeam}`;
+      }
+  
+      // Team Schedule
+      const teamAbbrMap = new Map(allCBBTeams.map((team) => [team.ID, team.Abbr]));
+      const teamSchedule = allCBBGames
+        .filter((game) => game.HomeTeamID === team.ID || 
+                          game.AwayTeamID === team.ID)
+        .map((game) => ({
+          ...game,
+          HomeTeamAbbr: teamAbbrMap.get(game.HomeTeamID),
+          AwayTeamAbbr: teamAbbrMap.get(game.AwayTeamID),
+        }));
+  
+      // Team Stats
+      const userPoints = topCBBPoints.filter((p) => p.TeamID === team.ID);
+      const userAssists = topCBBAssists.filter((r) => r.TeamID === team.ID);
+      const userRebounds = topCBBRebounds.filter((rcv) => rcv.TeamID === team.ID);
+      const topPoints = userPoints.length > 0 ? userPoints[0] : null;
+      const topAssists = userAssists.length > 0 ? userAssists[0] : null;
+      const topRebounds = userRebounds.length > 0 ? userRebounds[0] : null;
+  
+      const teamStats = {
+        TopPoints: topPoints,
+        TopAssists: topAssists,
+        TopRebounds: topRebounds
+      };
+  
+      // Team News
+      const teamNews = cbbNews
+        .filter((newsItem) => newsItem.TeamID === team.ID)
+        .slice(-10)
+        .reverse();
+  
+    return { 
+      teamStandings, 
+      teamNotifications, 
+      teamMatchUp, 
+      gameWeek,
+      teamSchedule, 
+      homeLogo, 
+      awayLogo, 
+      homeLabel, 
+      awayLabel, 
+      teamStats, 
+      teamNews 
+    };
+  };
+  
+  export const getLandingNBAData = (
+      team: any,
+      currentWeek: any,
+      league: League,
+      currentUser: any,
+      allNBAStandings: NBAStandings[],
+      nbaNotifications: BasketballNotification[],
+      allNBAGames: NBAMatch[],
+      allNBATeams: NBATeam[],
+      topNBAPoints: NBAPlayer[],
+      topNBAAssists: NBAPlayer[],
+      topNBARebounds: NBAPlayer[],
+      nbaNews: BasketballNewsLog[],
+    ) => {
+        // Team Standings
+        const teamStandings = allNBAStandings
+          .filter((standings) => standings.ConferenceID === team.ConferenceID)
+          .map((standings, index) => ({ ...standings, Rank: index + 1 }));
+          console.log(teamStandings)
+        
+        // Team Notifications
+        const teamNotifications = nbaNotifications
+          .filter((notification) => notification.TeamID === team.ID)
+          .reverse();
+        
+        // Team Match-Up
+        let foundMatch: NBAMatch[] | null = null;
+        let gameWeek = currentWeek;
+        for (let weekOffset = 0; weekOffset <= 10; weekOffset++) {
+          const testWeek = currentWeek + weekOffset;
+          const nextMatch = allNBAGames.filter(
+            (game) =>
+              (game.HomeTeamID === team.ID || game.AwayTeamID === team.ID) &&
+              game.Week === testWeek
+          );
+        
+          if (nextMatch.length > 0) {
+            foundMatch = nextMatch;
+            gameWeek = testWeek;
+            break;
+          }
+        }
+      
+        const teamMatchUp = foundMatch || [];
+        let homeLogo = "";
+        let awayLogo = "";
+        let homeLabel = "";
+        let awayLabel = "";
+        
+        if (teamMatchUp.length > 0) {
+          homeLogo = getLogo(league, 
+            teamMatchUp[0].HomeTeamID, 
+            currentUser?.isRetro);
+          awayLogo = getLogo(league, 
+            teamMatchUp[0].AwayTeamID, 
+            currentUser?.isRetro);
+          homeLabel = teamMatchUp[0].HomeTeam;
+          awayLabel = teamMatchUp[0].AwayTeam;
+        }
+  
+        // Team Schedule
+        const teamAbbrMap = new Map(allNBATeams.map((team) => [team.ID, team.Abbr]));
+        const teamSchedule = allNBAGames
+          .filter((game) => game.HomeTeamID === team.ID || 
+                            game.AwayTeamID === team.ID)
+          .map((game) => ({
+            ...game,
+            HomeTeamAbbr: teamAbbrMap.get(game.HomeTeamID),
+            AwayTeamAbbr: teamAbbrMap.get(game.AwayTeamID),
+          }));
+  
+        // Team Stats
+        const userPoints = topNBAPoints.filter((p) => p.TeamID === team.ID);
+        const userAssists = topNBAAssists.filter((r) => r.TeamID === team.ID);
+        const userRebounds = topNBARebounds.filter((rcv) => rcv.TeamID === team.ID);
+        const topPoints = userPoints.length > 0 ? userPoints[0] : null;
+        const topAssists = userAssists.length > 0 ? userAssists[0] : null;
+        const topRebounds = userRebounds.length > 0 ? userRebounds[0] : null;
+  
+        const teamStats = {
+          TopPoints: topPoints,
+          TopAssists: topAssists,
+          TopRebounds: topRebounds
+        };
+  
+        // Team News
+        const teamNews = nbaNews
+          .filter((newsItem) => newsItem.TeamID === team.ID)
+          .slice(-10)
+          .reverse(); 
+        
+      return { 
+        teamStandings, 
+        teamNotifications, 
+        teamMatchUp, 
+        gameWeek, 
+        teamSchedule, 
+        homeLogo, 
+        awayLogo, 
+        homeLabel, 
+        awayLabel, 
+        teamStats, 
+        teamNews 
+      };
+    };
 
 
   export const getLandingCHLData = (

--- a/src/components/LandingPage/TeamLandingPageHelper.tsx
+++ b/src/components/LandingPage/TeamLandingPageHelper.tsx
@@ -339,6 +339,7 @@ export const getLandingNFLData = (
         TopAssists: topAssists,
         TopRebounds: topRebounds
       };
+      console.log(teamStats)
   
       // Team News
       const teamNews = cbbNews
@@ -445,6 +446,7 @@ export const getLandingNFLData = (
           TopAssists: topAssists,
           TopRebounds: topRebounds
         };
+        console.log(teamStats)
   
         // Team News
         const teamNews = nbaNews

--- a/src/components/LandingPage/TeamLandingPageHelper.tsx
+++ b/src/components/LandingPage/TeamLandingPageHelper.tsx
@@ -165,7 +165,6 @@ export const getLandingNFLData = (
       const teamStandings = allProStandings
         .filter((standings) => standings.ConferenceID === team.ConferenceID)
         .map((standings, index) => ({ ...standings, Rank: index + 1 }));
-        console.log(teamStandings)
       
       // Team Notifications
       const teamNotifications = proNotifications

--- a/src/components/LandingPage/TeamLandingPageTitles.tsx
+++ b/src/components/LandingPage/TeamLandingPageTitles.tsx
@@ -2,20 +2,31 @@
 export const fbPassStats = "Passing Leader";
 export const fbRushStats = "Rushing Leader";
 export const fbReceivingStats = "Receiving Leader";
+export const fbTdAbbr = "TD";
+export const fbYardsAbbr = "Yards";
 export const hkPointsStats = "Points Leader";
 export const hkGoalsStats = "Goals Leader";
 export const hkAssistsStats = "Assists Leader";
+export const hkGamesAbbr = "Games Played";
+export const hkPointsAbbr = "Points";
+export const hkGoalsAbbr = "Goals";
+export const hkAssistsAbbr = "Assists";
 export const bbPpgStats = "Points Per Game Leader";
-export const bbRpgStats = "Rebounds Per Game Leader";
 export const bbApgStats = "Assists Per Game Leader";
+export const bbRpgStats = "Rebounds Per Game Leader";
+export const bbGamesAbbr = "Games Played";
+export const bbPpgAbbr = "PPG";
+export const bbApgAbbr = "APG";
+export const bbRpgAbbr = "RPG";
+
 
 export const headersMapping = {
-    SimCFB: [fbPassStats, fbRushStats, fbReceivingStats],
-    SimNFL: [fbPassStats, fbRushStats, fbReceivingStats],
-    SimCHL: [hkPointsStats, hkGoalsStats, hkAssistsStats],
-    SimPHL: [hkPointsStats, hkGoalsStats, hkAssistsStats],
-    SimCBB: [bbPpgStats, bbRpgStats, bbApgStats],
-    SimNBA: [bbPpgStats, bbRpgStats, bbApgStats],
+    SimCFB: [fbPassStats, fbRushStats, fbReceivingStats, fbTdAbbr, fbYardsAbbr],
+    SimNFL: [fbPassStats, fbRushStats, fbReceivingStats, fbTdAbbr, fbYardsAbbr],
+    SimCHL: [hkPointsStats, hkGoalsStats, hkAssistsStats, hkGamesAbbr, hkPointsAbbr, hkGoalsAbbr, hkAssistsAbbr],
+    SimPHL: [hkPointsStats, hkGoalsStats, hkAssistsStats, hkGamesAbbr, hkPointsAbbr, hkGoalsAbbr, hkAssistsAbbr],
+    SimCBB: [bbPpgStats, bbApgStats, bbRpgStats, bbGamesAbbr, bbPpgAbbr, bbApgAbbr, bbRpgAbbr],
+    SimNBA: [bbPpgStats, bbApgStats, bbRpgStats, bbGamesAbbr, bbPpgAbbr, bbApgAbbr, bbRpgAbbr],
   } as const;
 
   export type LeagueType = keyof typeof headersMapping;

--- a/src/components/LandingPage/TeamLandingPageTitles.tsx
+++ b/src/components/LandingPage/TeamLandingPageTitles.tsx
@@ -2,31 +2,31 @@
 export const fbPassStats = "Passing Leader";
 export const fbRushStats = "Rushing Leader";
 export const fbReceivingStats = "Receiving Leader";
-export const fbTdAbbr = "TD";
+export const fbTdAbbr = "TDs";
 export const fbYardsAbbr = "Yards";
 export const hkPointsStats = "Points Leader";
 export const hkGoalsStats = "Goals Leader";
 export const hkAssistsStats = "Assists Leader";
-export const hkGamesAbbr = "Games Played";
+export const hkGamesAbbr = "GP";
 export const hkPointsAbbr = "Points";
 export const hkGoalsAbbr = "Goals";
 export const hkAssistsAbbr = "Assists";
-export const bbPpgStats = "Points Per Game Leader";
-export const bbApgStats = "Assists Per Game Leader";
-export const bbRpgStats = "Rebounds Per Game Leader";
-export const bbGamesAbbr = "Games Played";
+export const bbPpgStats = "Points Leader";
+export const bbApgStats = "Assists Leader";
+export const bbRpgStats = "Rebounds Leader";
+export const bbGamesAbbr = "GP";
 export const bbPpgAbbr = "PPG";
 export const bbApgAbbr = "APG";
 export const bbRpgAbbr = "RPG";
 
 
 export const headersMapping = {
-    SimCFB: [fbPassStats, fbRushStats, fbReceivingStats, fbTdAbbr, fbYardsAbbr],
-    SimNFL: [fbPassStats, fbRushStats, fbReceivingStats, fbTdAbbr, fbYardsAbbr],
-    SimCHL: [hkPointsStats, hkGoalsStats, hkAssistsStats, hkGamesAbbr, hkPointsAbbr, hkGoalsAbbr, hkAssistsAbbr],
-    SimPHL: [hkPointsStats, hkGoalsStats, hkAssistsStats, hkGamesAbbr, hkPointsAbbr, hkGoalsAbbr, hkAssistsAbbr],
-    SimCBB: [bbPpgStats, bbApgStats, bbRpgStats, bbGamesAbbr, bbPpgAbbr, bbApgAbbr, bbRpgAbbr],
-    SimNBA: [bbPpgStats, bbApgStats, bbRpgStats, bbGamesAbbr, bbPpgAbbr, bbApgAbbr, bbRpgAbbr],
+    SimCFB: [fbPassStats, fbRushStats, fbReceivingStats, fbTdAbbr, fbYardsAbbr, fbTdAbbr, fbYardsAbbr, fbTdAbbr, fbYardsAbbr],
+    SimNFL: [fbPassStats, fbRushStats, fbReceivingStats, fbTdAbbr, fbYardsAbbr, fbTdAbbr, fbYardsAbbr, fbTdAbbr, fbYardsAbbr],
+    SimCHL: [hkPointsStats, hkGoalsStats, hkAssistsStats, hkGamesAbbr, hkPointsAbbr, hkGamesAbbr, hkGoalsAbbr, hkGamesAbbr, hkAssistsAbbr],
+    SimPHL: [hkPointsStats, hkGoalsStats, hkAssistsStats, hkGamesAbbr, hkPointsAbbr, hkGamesAbbr, hkGoalsAbbr, hkGamesAbbr, hkAssistsAbbr],
+    SimCBB: [bbPpgStats, bbApgStats, bbRpgStats, bbGamesAbbr, bbPpgAbbr, bbGamesAbbr, bbApgAbbr, bbGamesAbbr, bbRpgAbbr],
+    SimNBA: [bbPpgStats, bbApgStats, bbRpgStats, bbGamesAbbr, bbPpgAbbr, bbGamesAbbr, bbApgAbbr, bbGamesAbbr, bbRpgAbbr],
   } as const;
 
   export type LeagueType = keyof typeof headersMapping;

--- a/src/components/LandingPage/TeamLandingPageTitles.tsx
+++ b/src/components/LandingPage/TeamLandingPageTitles.tsx
@@ -7,14 +7,14 @@ export const fbYardsAbbr = "Yards";
 export const hkPointsStats = "Points Leader";
 export const hkGoalsStats = "Goals Leader";
 export const hkAssistsStats = "Assists Leader";
-export const hkGamesAbbr = "GP";
+export const hkGamesAbbr = "TOI";
 export const hkPointsAbbr = "Points";
 export const hkGoalsAbbr = "Goals";
 export const hkAssistsAbbr = "Assists";
 export const bbPpgStats = "Points Leader";
 export const bbApgStats = "Assists Leader";
 export const bbRpgStats = "Rebounds Leader";
-export const bbGamesAbbr = "GP";
+export const bbGamesAbbr = "MIN";
 export const bbPpgAbbr = "PPG";
 export const bbApgAbbr = "APG";
 export const bbRpgAbbr = "RPG";
@@ -23,10 +23,10 @@ export const bbRpgAbbr = "RPG";
 export const headersMapping = {
     SimCFB: [fbPassStats, fbRushStats, fbReceivingStats, fbTdAbbr, fbYardsAbbr, fbTdAbbr, fbYardsAbbr, fbTdAbbr, fbYardsAbbr],
     SimNFL: [fbPassStats, fbRushStats, fbReceivingStats, fbTdAbbr, fbYardsAbbr, fbTdAbbr, fbYardsAbbr, fbTdAbbr, fbYardsAbbr],
-    SimCHL: [hkPointsStats, hkGoalsStats, hkAssistsStats, hkGamesAbbr, hkPointsAbbr, hkGamesAbbr, hkGoalsAbbr, hkGamesAbbr, hkAssistsAbbr],
-    SimPHL: [hkPointsStats, hkGoalsStats, hkAssistsStats, hkGamesAbbr, hkPointsAbbr, hkGamesAbbr, hkGoalsAbbr, hkGamesAbbr, hkAssistsAbbr],
-    SimCBB: [bbPpgStats, bbApgStats, bbRpgStats, bbGamesAbbr, bbPpgAbbr, bbGamesAbbr, bbApgAbbr, bbGamesAbbr, bbRpgAbbr],
-    SimNBA: [bbPpgStats, bbApgStats, bbRpgStats, bbGamesAbbr, bbPpgAbbr, bbGamesAbbr, bbApgAbbr, bbGamesAbbr, bbRpgAbbr],
+    SimCHL: [hkPointsStats, hkGoalsStats, hkAssistsStats, hkPointsAbbr, hkGamesAbbr, hkGoalsAbbr, hkGamesAbbr, hkAssistsAbbr, hkGamesAbbr],
+    SimPHL: [hkPointsStats, hkGoalsStats, hkAssistsStats, hkPointsAbbr, hkGamesAbbr, hkGoalsAbbr, hkGamesAbbr, hkAssistsAbbr, hkGamesAbbr],
+    SimCBB: [bbPpgStats, bbApgStats, bbRpgStats, bbPpgAbbr, bbGamesAbbr, bbApgAbbr, bbGamesAbbr, bbRpgAbbr, bbGamesAbbr],
+    SimNBA: [bbPpgStats, bbApgStats, bbRpgStats, bbPpgAbbr, bbGamesAbbr, bbApgAbbr, bbGamesAbbr, bbRpgAbbr, bbGamesAbbr],
   } as const;
 
   export type LeagueType = keyof typeof headersMapping;

--- a/src/components/LandingPage/TeamLandingPageTitles.tsx
+++ b/src/components/LandingPage/TeamLandingPageTitles.tsx
@@ -16,8 +16,8 @@ export const bbApgStats = "Assists Leader";
 export const bbRpgStats = "Rebounds Leader";
 export const bbGamesAbbr = "MIN";
 export const bbPpgAbbr = "PPG";
-export const bbApgAbbr = "APG";
-export const bbRpgAbbr = "RPG";
+export const bbApgAbbr = "AST";
+export const bbRpgAbbr = "REB";
 
 
 export const headersMapping = {

--- a/src/context/SimBBAContext.tsx
+++ b/src/context/SimBBAContext.tsx
@@ -3,11 +3,32 @@ import {
   ReactNode,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { useAuthStore } from "./AuthContext";
-import { NBATeam, Team, Timestamp } from "../models/basketballModels";
+import { 
+  NBATeam,
+  Team,
+  CollegeStandings, 
+  Timestamp,
+  CollegePlayer,
+  Croot,
+  TeamRecruitingProfile,
+  Match,
+  NewsLog, 
+  Notification,
+  NBAStandings,
+  NBAPlayer,
+  NBAMatch,
+  FreeAgencyResponse,
+  NBACapsheet, 
+  Gameplan,
+  NBAGameplan,
+  TransferPlayerResponse
+} from "../models/basketballModels";
 import { useWebSockets } from "../_hooks/useWebsockets";
+import { BootstrapService } from "../_services/bootstrapService";
 import { bba_ws } from "../_constants/urls";
 import { SimBBA } from "../_constants/constants";
 
@@ -15,6 +36,8 @@ import { SimBBA } from "../_constants/constants";
 interface SimBBAContextProps {
   cbb_Timestamp: Timestamp | null;
   isLoading: boolean;
+  isLoadingTwo: boolean;
+  isLoadingThree: boolean;
   cbbTeam: Team | null;
   cbbTeams: Team[];
   cbbTeamOptions: { label: string; value: string }[];
@@ -23,12 +46,49 @@ interface SimBBAContextProps {
   nbaTeams: NBATeam[];
   nbaTeamOptions: { label: string; value: string }[];
   nbaConferenceOptions: { label: string; value: string }[];
+  cbbTeamMap: Record<number, Team> | null;
+  currentCBBStandings: CollegeStandings[],
+  cbbStandingsMap: Record<number, CollegeStandings> | null;
+  cbbRosterMap: Record<number, CollegePlayer[]> | null;
+  recruits: Croot[];
+  teamProfileMap: Record<number, TeamRecruitingProfile> | null;
+  portalPlayers: TransferPlayerResponse[];
+  collegeInjuryReport: CollegePlayer[];
+  allCBBStandings: CollegeStandings[];
+  allCollegeGames: Match[];
+  currentCollegeSeasonGames: Match[];
+  collegeTeamsGames: Match[];
+  collegeNews: NewsLog[];
+  collegeNotifications: Notification[];
+  nbaTeamMap: Record<number, NBATeam> | null;
+  allProStandings: NBAStandings[];
+  currentProStandings: NBAStandings[];
+  proRosterMap: {
+    [key: number]: NBAPlayer[];
+  } | null;
+  freeAgency: FreeAgencyResponse | null;
+  capsheetMap: Record<number, NBACapsheet> | null;
+  proInjuryReport: NBAPlayer[];
+  proNews: NewsLog[];
+  allProGames: NBAMatch[];
+  currentProSeasonGames: NBAMatch[];
+  proNotifications: Notification[];
+  collegeGameplan: Gameplan[];
+  nbaGameplan: NBAGameplan[];
+  topCBBPoints: CollegePlayer[];
+  topCBBAssists: CollegePlayer[];
+  topCBBRebounds: CollegePlayer[];
+  topNBAPoints: NBAPlayer[];
+  topNBAAssists: NBAPlayer[];
+  topNBARebounds: NBAPlayer[];
 }
 
 // ✅ Initial Context State
 const defaultContext: SimBBAContextProps = {
   cbb_Timestamp: null,
   isLoading: true,
+  isLoadingTwo: true,
+  isLoadingThree: true,
   cbbTeam: null,
   cbbTeams: [],
   cbbTeamOptions: [],
@@ -37,6 +97,39 @@ const defaultContext: SimBBAContextProps = {
   nbaTeams: [],
   nbaTeamOptions: [],
   nbaConferenceOptions: [],
+  cbbTeamMap: {},
+  currentCBBStandings: [],
+  cbbStandingsMap: {},
+  cbbRosterMap: {},
+  recruits: [],
+  teamProfileMap: {},
+  portalPlayers: [],
+  collegeInjuryReport: [],
+  allCBBStandings: [],
+  allCollegeGames: [],
+  currentCollegeSeasonGames: [],
+  collegeTeamsGames: [],
+  collegeNews: [],
+  collegeNotifications: [],
+  nbaTeamMap: {},
+  allProStandings: [],
+  currentProStandings: [],
+  proRosterMap: {},
+  freeAgency: null,
+  capsheetMap: {},
+  proInjuryReport: [],
+  proNews: [],
+  allProGames: [],
+  currentProSeasonGames: [],
+  proNotifications: [],
+  collegeGameplan: [],
+  nbaGameplan: [],
+  topCBBPoints: [],
+  topCBBAssists: [],
+  topCBBRebounds: [],
+  topNBAPoints: [],
+  topNBAAssists: [],
+  topNBARebounds: [],
 };
 
 export const SimBBAContext = createContext<SimBBAContextProps>(defaultContext);
@@ -49,7 +142,10 @@ interface SimBBAProviderProps {
 export const SimBBAProvider: React.FC<SimBBAProviderProps> = ({ children }) => {
   const { currentUser } = useAuthStore();
   const { cbb_Timestamp } = useWebSockets(bba_ws, SimBBA);
+  const isFetching = useRef(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoadingTwo, setIsLoadingTwo] = useState<boolean>(true);
+  const [isLoadingThree, setIsLoadingThree] = useState<boolean>(true);
   const [cbbTeam, setCBBTeam] = useState<Team | null>(null);
   const [cbbTeams, setCBBTeams] = useState<Team[]>([]);
   const [cbbTeamOptions, setCBBTeamOptions] = useState<
@@ -66,15 +162,255 @@ export const SimBBAProvider: React.FC<SimBBAProviderProps> = ({ children }) => {
   const [nbaConferenceOptions, setNBAConferenceOptions] = useState<
     { label: string; value: string }[]
   >([]);
+  const [allCBBStandings, setAllCBBStandings] = useState<CollegeStandings[]>(
+    []
+  );
+  const [currentCBBStandings, setCurrentCBBStandings] = useState<
+    CollegeStandings[]
+  >([]);
+  const [cbbStandingsMap, setCBBStandingsMap] = useState<Record<
+    number,
+    CollegeStandings
+  > | null>({});
+  const [cbbRosterMap, setCBBRosterMap] = useState<Record<
+    number,
+    CollegePlayer[]
+  > | null>({});
+  const [recruits, setRecruits] = useState<Croot[]>([]);
+  const [teamProfileMap, setTeamProfileMap] = useState<Record<
+    number,
+    TeamRecruitingProfile
+  > | null>({});
+  const [portalPlayers, setPortalPlayers] = useState<TransferPlayerResponse[]>([]);
+  const [collegeInjuryReport, setCollegeInjuryReport] = useState<
+    CollegePlayer[]
+  >([]);
+  const [collegeNews, setCollegeNews] = useState<NewsLog[]>([]);
+  const [allCollegeGames, setAllCollegeGames] = useState<Match[]>([]);
+  const [currentCollegeSeasonGames, setCurrentCollegeSeasonGames] = useState<
+    Match[]
+  >([]);
+  const [collegeTeamsGames, setCollegeTeamsGames] = useState<Match[]>([]);
+  const [collegeNotifications, setCollegeNotifications] = useState<
+    Notification[]
+  >([]);
+  const [cbbTeamMap, setCBBTeamMap] = useState<Record<number, Team>>({});
+  const [nbaTeamMap, setProTeamMap] = useState<Record<number, NBATeam> | null>(
+    {}
+  );
+  const [allProStandings, setAllProStandings] = useState<NBAStandings[]>([]);
+  const [currentProStandings, setCurrentProStandings] = useState<
+    NBAStandings[]
+  >([]);
+  const [proStandingsMap, setProStandingsMap] = useState<Record<
+    number,
+    NBAStandings
+  > | null>({});
+  const [proRosterMap, setProRosterMap] = useState<{
+    [key: number]: NBAPlayer[];
+  } | null>({});
+  const [freeAgency, setFreeAgency] = useState<FreeAgencyResponse | null>(null);
+  const [capsheetMap, setCapsheetMap] = useState<Record<
+    number,
+    NBACapsheet
+  > | null>({});
+  const [proInjuryReport, setProInjuryReport] = useState<NBAPlayer[]>([]);
+  const [proNews, setProNews] = useState<NewsLog[]>([]);
+  const [allProGames, setAllProGames] = useState<NBAMatch[]>([]);
+  const [currentProSeasonGames, setCurrentProSeasonGames] = useState<NBAMatch[]>(
+    []
+  );
+  const [collegeGameplan, setCollegeGameplan] = useState<Gameplan[]>([]);
+  const [nbaGameplan, setNBAGameplan] = useState<NBAGameplan[]>([]);
+  const [proTeamsGames, setProTeamsGames] = useState<NBAMatch[]>([]);
+  const [proNotifications, setProNotifications] = useState<Notification[]>([]);
+  const [topCBBPoints, setTopCBBPoints] = useState<CollegePlayer[]>([]);
+  const [topCBBAssists, setTopCBBAssists] = useState<CollegePlayer[]>([]);
+  const [topCBBRebounds, setTopCBBRebounds] = useState<CollegePlayer[]>([]);
+  const [topNBAPoints, setTopNBAPoints] = useState<NBAPlayer[]>([]);
+  const [topNBAAssists, setTopNBAAssists] = useState<NBAPlayer[]>([]);
+  const [topNBARebounds, setTopNBARebounds] = useState<NBAPlayer[]>([]);
 
-  useEffect(() => {}, []);
+  useEffect(() => {
+    if (currentUser && !isFetching.current) {
+      isFetching.current = true;
+      bootstrapAllData();
+    }
+  }, [currentUser]);
+
+  const bootstrapAllData = async () => {
+    await getFirstBootstrapData();
+    await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait 5 seconds
+    await getSecondBootstrapData();
+    await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait 5 seconds
+    await getThirdBootstrapData();
+    isFetching.current = false;
+  };
+
+  const getFirstBootstrapData = async () => {
+    let cbbID = 0;
+    let nbaID = 0;
+    if (currentUser && currentUser.cbb_id) {
+      cbbID = currentUser.cbb_id;
+    }
+    if (currentUser && currentUser.NBATeamID) {
+      nbaID = currentUser.NBATeamID;
+    }
+    const res = await BootstrapService.GetBBABootstrapData(cbbID, nbaID);
+    console.log({ res });
+    setCBBTeam(res.CollegeTeam);
+    setCBBTeams(res.AllCollegeTeams);
+    setNBATeam(res.NBATeam);
+    setNBATeams(res.AllProTeams);
+    setCollegeInjuryReport(res.CollegeInjuryReport);
+    setCollegeNotifications(res.CollegeNotifications);
+    setCBBRosterMap(res.CollegeRosterMap);
+    setPortalPlayers(res.PortalPlayers);
+    setProNotifications(res.ProNotifications);
+    setCollegeGameplan(res.CollegeGameplan)
+    setNBAGameplan(res.NBAGameplan)
+    setTopCBBPoints(res.TopCBBPoints);
+    setTopCBBAssists(res.TopCBBAssists);
+    setTopCBBRebounds(res.TopCBBRebounds);
+
+    if (res.AllCollegeTeams.length > 0) {
+      const sortedCollegeTeams = res.AllCollegeTeams.sort((a, b) =>
+        a.Team.localeCompare(b.Team)
+      );
+      const teamOptionsList = sortedCollegeTeams.map((team) => ({
+        label: team.Team,
+        value: team.ID.toString(),
+      }));
+      const conferenceOptions = Array.from(
+        new Map(
+          sortedCollegeTeams.map((team) => [
+            team.ConferenceID,
+            { label: team.Conference, value: team.ConferenceID.toString() },
+          ])
+        ).values()
+      ).sort((a, b) => a.label.localeCompare(b.label));
+      setCBBTeamOptions(teamOptionsList);
+      setCBBConferenceOptions(conferenceOptions);
+      const collegeTeamMap = Object.fromEntries(
+        sortedCollegeTeams.map((team) => [team.ID, team])
+      );
+      setCBBTeamMap(collegeTeamMap);
+    }
+    if (res.AllProTeams.length > 0) {
+      const sortedNBATeams = res.AllProTeams.sort((a, b) =>
+        a.Team.localeCompare(b.Team)
+      );
+      const nbaTeamOptions = sortedNBATeams.map((team) => ({
+        label: team.Team,
+        value: team.ID.toString(),
+      }));
+      const nbaConferenceOptions = Array.from(
+        new Map(
+          sortedNBATeams.map((team) => [
+            team.ConferenceID,
+            { label: team.Conference, value: team.ConferenceID.toString() },
+          ])
+        ).values()
+      ).sort((a, b) => a.label.localeCompare(b.label));
+      setNBATeamOptions(nbaTeamOptions);
+      setNBAConferenceOptions(nbaConferenceOptions);
+      const nbaTeamMap = Object.fromEntries(
+        sortedNBATeams.map((team) => [team.ID, team])
+      );
+      setProTeamMap(nbaTeamMap);
+    }
+    setIsLoading(false);
+  };
+
+  const getSecondBootstrapData = async () => {
+    let cbbID = 0;
+    let nbaID = 0;
+    if (currentUser && currentUser.cbb_id) {
+      cbbID = currentUser.cbb_id;
+    }
+    if (currentUser && currentUser.NBATeamID) {
+      nbaID = currentUser.NBATeamID;
+    }
+    const res = await BootstrapService.GetSecondBBABootstrapData(cbbID, nbaID);
+    setCollegeNews(res.CollegeNews);
+    setTeamProfileMap(res.TeamProfileMap);
+    setTopNBAPoints(res.TopNBAPoints);
+    setTopNBAAssists(res.TopNBAAssists);
+    setTopNBARebounds(res.TopNBARebounds);
+    setAllCBBStandings(res.CollegeStandings);
+    if (res.CollegeStandings.length > 0 && cbb_Timestamp) {
+      const currentSeasonStandings = res.CollegeStandings.filter(
+        (x) => x.SeasonID === cbb_Timestamp.SeasonID
+      );
+      const collegeStandingsMap = Object.fromEntries(
+        currentSeasonStandings.map((standings) => [standings.TeamID, standings])
+      );
+      setCurrentCBBStandings(currentSeasonStandings);
+      setCBBStandingsMap(collegeStandingsMap);
+    }
+    setCapsheetMap(res.CapsheetMap);
+    setProRosterMap(res.ProRosterMap);
+    setProInjuryReport(res.ProInjuryReport);
+    setAllProStandings(res.ProStandings);
+    if (res.ProStandings.length > 0 && cbb_Timestamp) {
+      const currentSeasonStandings = res.ProStandings.filter(
+        (x) => x.SeasonID === cbb_Timestamp.SeasonID
+      );
+      const nbaStandingsMap = Object.fromEntries(
+        currentSeasonStandings.map((standings) => [standings.TeamID, standings])
+      );
+      setCurrentProStandings(currentSeasonStandings);
+      setProStandingsMap(nbaStandingsMap);
+    }
+    setIsLoadingTwo(false);
+  };
+
+  const getThirdBootstrapData = async () => {
+    let cbbID = 0;
+    let nbaID = 0;
+    if (currentUser && currentUser.cbb_id) {
+      cbbID = currentUser.cbb_id;
+    }
+    if (currentUser && currentUser.NBATeamID) {
+      nbaID = currentUser.NBATeamID;
+    }
+    const res = await BootstrapService.GetThirdBBABootstrapData(cbbID, nbaID);
+    setProNews(res.ProNews);
+    setRecruits(res.Recruits);
+    setFreeAgency(res.FreeAgency);
+    setAllCollegeGames(res.AllCollegeGames);
+    if (res.AllCollegeGames.length > 0 && cbb_Timestamp) {
+      const currentSeasonGames = res.AllCollegeGames.filter(
+        (x) => x.SeasonID === cbb_Timestamp.SeasonID
+      );
+      setCurrentCollegeSeasonGames(currentSeasonGames);
+      const teamGames = currentSeasonGames.filter(
+        (x) => x.HomeTeamID === cbbID || x.AwayTeamID === cbbID
+      );
+      setCollegeTeamsGames(teamGames);
+    }
+    setAllProGames(res.AllProGames);
+    if (res.AllProGames.length > 0 && cbb_Timestamp) {
+      const currentSeasonGames = res.AllProGames.filter(
+        (x) => x.SeasonID === cbb_Timestamp.SeasonID
+      );
+      setCurrentProSeasonGames(currentSeasonGames);
+      const teamGames = currentSeasonGames.filter(
+        (x) => x.HomeTeamID === nbaID || x.AwayTeamID === nbaID
+      );
+      setProTeamsGames(teamGames);
+    }
+    setIsLoadingThree(false);
+  };
 
   return (
     <SimBBAContext.Provider
       value={{
         cbb_Timestamp,
-        cbbTeam,
         isLoading,
+        isLoadingTwo,
+        isLoadingThree,
+        cbbTeam,
         cbbTeams,
         cbbTeamOptions,
         cbbConferenceOptions,
@@ -82,6 +418,39 @@ export const SimBBAProvider: React.FC<SimBBAProviderProps> = ({ children }) => {
         nbaTeams,
         nbaTeamOptions,
         nbaConferenceOptions,
+        cbbTeamMap,
+        currentCBBStandings,
+        cbbStandingsMap,
+        cbbRosterMap,
+        recruits,
+        teamProfileMap,
+        portalPlayers,
+        collegeInjuryReport,
+        allCBBStandings,
+        allCollegeGames,
+        currentCollegeSeasonGames,
+        collegeTeamsGames,
+        collegeNews,
+        collegeNotifications,
+        nbaTeamMap,
+        allProStandings,
+        currentProStandings,
+        proRosterMap,
+        freeAgency,
+        capsheetMap,
+        proInjuryReport,
+        proNews,
+        allProGames,
+        currentProSeasonGames,
+        proNotifications,
+        collegeGameplan,
+        nbaGameplan,
+        topCBBPoints,
+        topCBBAssists,
+        topCBBRebounds,
+        topNBAPoints,
+        topNBAAssists,
+        topNBARebounds,
       }}
     >
       {children}

--- a/src/context/SimBBAContext.tsx
+++ b/src/context/SimBBAContext.tsx
@@ -332,6 +332,7 @@ export const SimBBAProvider: React.FC<SimBBAProviderProps> = ({ children }) => {
       nbaID = currentUser.NBATeamID;
     }
     const res = await BootstrapService.GetSecondBBABootstrapData(cbbID, nbaID);
+    console.log({ res });
     setCollegeNews(res.CollegeNews);
     setTeamProfileMap(res.TeamProfileMap);
     setTopNBAPoints(res.TopNBAPoints);
@@ -375,6 +376,7 @@ export const SimBBAProvider: React.FC<SimBBAProviderProps> = ({ children }) => {
       nbaID = currentUser.NBATeamID;
     }
     const res = await BootstrapService.GetThirdBBABootstrapData(cbbID, nbaID);
+    console.log({ res });
     setProNews(res.ProNews);
     setRecruits(res.Recruits);
     setFreeAgency(res.FreeAgency);

--- a/src/models/basketballModels.ts
+++ b/src/models/basketballModels.ts
@@ -3384,85 +3384,109 @@ export class Team {
 }
 export class BootstrapData {
   AllCollegeTeams: Team[];
-  CollegeStandings: CollegeStandings[];
+  CollegeTeam: Team;
   CollegeRosterMap: { [key: number]: CollegePlayer[] };
-  Recruits: Croot[];
-  TeamProfileMap: { [key: number]: TeamRecruitingProfile };
-  PortalPlayers: CollegePlayer[];
+  PortalPlayers: TransferPlayerResponse[];
   CollegeInjuryReport: CollegePlayer[];
-  CollegeNews: NewsLog[];
   CollegeNotifications: Notification[];
-  AllCollegeGames: Match[];
-  CollegeGameplan: Gameplan;
+  CollegeGameplan: Gameplan[];
+  TopCBBPoints: CollegePlayer[];
+  TopCBBAssists: CollegePlayer[];
+  TopCBBRebounds: CollegePlayer[];
+  NBATeam: NBATeam;
   AllProTeams: NBATeam[];
-  ProStandings: NBAStandings[];
-  ProRosterMap: { [key: number]: NBAPlayer[] };
-  CapsheetMap: { [key: number]: NBACapsheet };
-  FreeAgency: FreeAgencyResponse;
-  ProInjuryReport: NBAPlayer[];
-  ProNews: NewsLog[];
   ProNotifications: Notification[];
+  NBAGameplan: NBAGameplan[];
+  CollegeNews: NewsLog[];
+  TeamProfileMap: { [key: string]: TeamRecruitingProfile };
+  CollegeStandings: CollegeStandings[];
+  ProStandings: NBAStandings[];
+  CapsheetMap: { [key: number]: NBACapsheet };
+  ProRosterMap: { [key: number]: NBAPlayer[] };
+  TopNBAPoints: NBAPlayer[];
+  TopNBAAssists: NBAPlayer[];
+  TopNBARebounds: NBAPlayer[];
+  ProInjuryReport: NBAPlayer[];
+  Recruits: Croot[];
+  FreeAgency: FreeAgencyResponse;
+  ProNews: NewsLog[];
+  AllCollegeGames: Match[];
   AllProGames: NBAMatch[];
-  NBAGameplan: NBAGameplan;
 
   constructor(source: any = {}) {
     if ("string" === typeof source) source = JSON.parse(source);
     this.AllCollegeTeams = this.convertValues(source["AllCollegeTeams"], Team);
-    this.CollegeStandings = this.convertValues(
-      source["CollegeStandings"],
-      CollegeStandings
-    );
+    this.CollegeTeam = this.convertValues(source["CollegeTeam"], Team);
     this.CollegeRosterMap = source["CollegeRosterMap"];
-    this.Recruits = this.convertValues(source["Recruits"], Croot);
-    this.TeamProfileMap = this.convertValues(
-      source["TeamProfileMap"],
-      TeamRecruitingProfile,
-      true
-    );
     this.PortalPlayers = this.convertValues(
       source["PortalPlayers"],
-      CollegePlayer
+      TransferPlayerResponse
     );
     this.CollegeInjuryReport = this.convertValues(
       source["CollegeInjuryReport"],
       CollegePlayer
     );
-    this.CollegeNews = this.convertValues(source["CollegeNews"], NewsLog);
     this.CollegeNotifications = this.convertValues(
       source["CollegeNotifications"],
       Notification
     );
-    this.AllCollegeGames = this.convertValues(source["AllCollegeGames"], Match);
     this.CollegeGameplan = this.convertValues(
       source["CollegeGameplan"],
       Gameplan
     );
+    this.TopCBBPoints = this.convertValues(
+      source["TopCBBPoints"],
+      CollegePlayer
+    );
+    this.TopCBBAssists = this.convertValues(
+      source["TopCBBAssists"],
+      CollegePlayer
+    );
+    this.TopCBBRebounds = this.convertValues(
+      source["TopCBBRebounds"],
+      CollegePlayer
+    );
+    this.NBATeam = this.convertValues(source["NBATeam"], NBATeam);
     this.AllProTeams = this.convertValues(source["AllProTeams"], NBATeam);
+    this.ProNotifications = this.convertValues(
+      source["ProNotifications"],
+      Notification
+    );
+    this.NBAGameplan = this.convertValues(source["NBAGameplan"], NBAGameplan);
+    this.CollegeNews = this.convertValues(source["CollegeNews"], NewsLog);
+    this.TeamProfileMap = source["TeamProfileMap"];
+    this.CollegeStandings = this.convertValues(
+      source["CollegeStandings"],
+      CollegeStandings
+    );
     this.ProStandings = this.convertValues(
       source["ProStandings"],
       NBAStandings
     );
-    this.ProRosterMap = source["ProRosterMap"];
     this.CapsheetMap = this.convertValues(
       source["CapsheetMap"],
       NBACapsheet,
       true
     );
-    this.FreeAgency = this.convertValues(
-      source["FreeAgency"],
-      FreeAgencyResponse
+    this.ProRosterMap = source["ProRosterMap"];
+    this.TopNBAPoints = this.convertValues(source["TopNBAPoints"], NBAPlayer);
+    this.TopNBAAssists = this.convertValues(source["TopNBAAssists"], NBAPlayer);
+    this.TopNBARebounds = this.convertValues(
+      source["TopNBARebounds"],
+      NBAPlayer
     );
     this.ProInjuryReport = this.convertValues(
       source["ProInjuryReport"],
       NBAPlayer
     );
-    this.ProNews = this.convertValues(source["ProNews"], NewsLog);
-    this.ProNotifications = this.convertValues(
-      source["ProNotifications"],
-      Notification
+    this.Recruits = this.convertValues(source["Recruits"], Croot);
+    this.FreeAgency = this.convertValues(
+      source["FreeAgency"],
+      FreeAgencyResponse
     );
+    this.ProNews = this.convertValues(source["ProNews"], NewsLog);
+    this.AllCollegeGames = this.convertValues(source["AllCollegeGames"], Match);
     this.AllProGames = this.convertValues(source["AllProGames"], NBAMatch);
-    this.NBAGameplan = this.convertValues(source["NBAGameplan"], NBAGameplan);
   }
 
   convertValues(a: any, classs: any, asMap: boolean = false): any {


### PR DESCRIPTION
SimBBA context file completed, and Landing Page now incorporates Basketball, as well as Football and Hockey. A number of changes have been made and the Landing Stats are now fully integrated (outside of the Hockey helper file, which is commented out and will be completed once hockey top stats are available on the bootstrap call).

- SimBBAContext.tsx now updated and has full capabilities similar to SimFBA.
  - Data is pulled in via three separate bootstrap calls, these are structured as requested
  - BasketballModels adapted courtesy of yourself.
- TeamLandingPage.tsx now functions for Basketball. Pill buttons activated. The Pill Buttons will need to have some work done on the logic so they do not display to users who are not involved in that league. At present I believe all buttons display to all users and are blank if user does not manage a team in the league.
- TeamLandingPageHelper.tsx completed for SimCBB and SimNBA. All that is outstanding is finishing the logic for the hockey stats, this is in place and is commented out at present but will be completed once top stats are available/
- TeamLandingPageTitles.tsx has been updated to cater for all three sports and also to cater for sub headers which are displayed next to the relevant stats.
- TeamLandingPageComponents.tsx now features a switch statement in TeamStats function which will ensure correct stats are displayed for each league. This utilises box headers which are then appropriately displayed in the stats box.

Please note, I had limited capabilities testing the CBB/NBA landing pages but it appears data is pulling through correctly. Please advise if there are any issues and can get them patched but I don't anticipate any.

Screenshots:

![image](https://github.com/user-attachments/assets/f66b9a4b-5c2d-4822-8a6b-af38ae985b41)
![image](https://github.com/user-attachments/assets/6bd6d1da-421d-474f-8340-4894283c51ae)
