### PR TITLE
Change conditional on pill buttons

### DIFF
--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -88,7 +88,7 @@ export const Home = () => {
       <div className="flex flex-col px-2 mt-1">
         <div className="flex flex-row mb-1">
           <ButtonGroup>
-            {cfbTeam && (
+            {currentUser?.teamId && cfbTeam && (
               <PillButton
                 variant="primaryOutline"
                 isSelected={selectedLeague === SimCFB}
@@ -97,7 +97,7 @@ export const Home = () => {
                 {cfbTeam.TeamName}
               </PillButton>
             )}
-            {nflTeam && (
+            {currentUser?.NFLTeamID && nflTeam && (
               <PillButton
                 variant="primaryOutline"
                 isSelected={selectedLeague === SimNFL}
@@ -106,7 +106,7 @@ export const Home = () => {
                 {nflTeam.Mascot}
               </PillButton>
             )}
-            {cbbTeam && (
+            {currentUser?.cbb_id && cbbTeam && (
               <PillButton
                 variant="primaryOutline"
                 isSelected={selectedLeague === SimCBB}
@@ -115,7 +115,7 @@ export const Home = () => {
                 {cbbTeam.Team}
               </PillButton>
             )}
-            {nbaTeam && (
+            {currentUser?.NBATeamID && nbaTeam && (
               <PillButton
                 variant="primaryOutline"
                 isSelected={selectedLeague === SimNBA}
@@ -124,7 +124,7 @@ export const Home = () => {
                 {nbaTeam.Nickname}
               </PillButton>
             )}
-            {chlTeam && (
+            {currentUser?.CHLTeamID && chlTeam && (
               <PillButton
                 variant="primaryOutline"
                 isSelected={selectedLeague === SimCHL}
@@ -133,7 +133,7 @@ export const Home = () => {
                 {chlTeam.TeamName}
               </PillButton>
             )}
-            {phlTeam && (
+            {currentUser?.PHLTeamID && phlTeam && (
               <PillButton
                 variant="primaryOutline"
                 isSelected={selectedLeague === SimPHL}


### PR DESCRIPTION
This PR relates to the change of the conditional check for the pill buttons on the home/landing page.

- Added check to ensure that the buttons for selecting teams are only displayed if the user has the corresponding team assigned to them and the team data is available.
  - For example, the button for selecting a college football team is now only displayed if the user has a a team id on their currentUser, and team data is available.
- Optional Chaining is used to safely access currentUser properties, guarding against if it is Null. 

Screenshot below.

![image](https://github.com/user-attachments/assets/ac7b23b3-79d3-4503-bf8e-8abf6e1ab4a5)
